### PR TITLE
fix(S3Context.cpp) : jours sur 2 chiffres pour meilleure compabilité S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Cette release contient les librairies C++, utilisées par les outils de [generat
 ### [Fixed]
 
 * Possibilité d'appliquer à la génération (dans mergeNtiff) un style définissant un calcul d'aspect ou de pente mais pas de palette (on reste alors avec un canal potentiellement flottant)
+* Passage du nombre de jours sur 2 chiffres dans les appels S3
 
 <!-- 
 ### [Added]

--- a/src/storage/object/S3Context.cpp
+++ b/src/storage/object/S3Context.cpp
@@ -195,7 +195,7 @@ int S3Context::read(uint8_t* data, int offset, int size, std::string name) {
 
     static char gmt_time[40];
     sprintf(
-        gmt_time, "%s, %d %s %d %.2d:%.2d:%.2d GMT",
+        gmt_time, "%s, %.2d %s %d %.2d:%.2d:%.2d GMT",
         wday_name[ptm->tm_wday], ptm->tm_mday, mon_name[ptm->tm_mon], 1900 + ptm->tm_year,
         ptm->tm_hour, ptm->tm_min, ptm->tm_sec
     );
@@ -293,7 +293,7 @@ uint8_t* S3Context::readFull(int& size, std::string name) {
 
     static char gmt_time[40];
     sprintf(
-        gmt_time, "%s, %d %s %d %.2d:%.2d:%.2d GMT",
+        gmt_time, "%s, %.2d %s %d %.2d:%.2d:%.2d GMT",
         wday_name[ptm->tm_wday], ptm->tm_mday, mon_name[ptm->tm_mon], 1900 + ptm->tm_year,
         ptm->tm_hour, ptm->tm_min, ptm->tm_sec
     );
@@ -462,7 +462,7 @@ bool S3Context::closeToWrite(std::string name) {
 
     static char gmt_time[40];
     sprintf(
-        gmt_time, "%s, %d %s %d %.2d:%.2d:%.2d GMT",
+        gmt_time, "%s, %.2d %s %d %.2d:%.2d:%.2d GMT",
         wday_name[ptm->tm_wday], ptm->tm_mday, mon_name[ptm->tm_mon], 1900 + ptm->tm_year,
         ptm->tm_hour, ptm->tm_min, ptm->tm_sec
     );


### PR DESCRIPTION
Sur des outils dont MinIO, le fait de ne pas mettre le jour sur 2 chiffres posent soucis lors des appels