### PR TITLE
fix byteswap: it's a gnu-ism

### DIFF
--- a/src/datasource/Decoder.cpp
+++ b/src/datasource/Decoder.cpp
@@ -42,7 +42,11 @@
 
 #include "jpeglib.h"
 #include "zlib.h"
-#include "byteswap.h"
+#if __has_include("byteswap.h")
+# include "byteswap.h"
+#else
+#include "utils/byteswap.h"
+#endif
 #include "compressors/LZWDecoder.h"
 #include "compressors/PKBDecoder.h"
 

--- a/src/datasource/PaletteDataSource.cpp
+++ b/src/datasource/PaletteDataSource.cpp
@@ -36,7 +36,12 @@
  */
 
 #include "datasource/PaletteDataSource.h"
-#include "byteswap.h"
+#if __has_include("byteswap.h")
+# include "byteswap.h"
+#else
+#include "utils/byteswap.h"
+#endif
+
 #include "zlib.h"
 #include <string.h>
 

--- a/src/datastream/PNGEncoder.cpp
+++ b/src/datastream/PNGEncoder.cpp
@@ -38,7 +38,12 @@
 #include <iostream>
 
 #include "datastream/PNGEncoder.h"
-#include "byteswap.h"
+#if __has_include("byteswap.h")
+# include "byteswap.h"
+#else
+#include "utils/byteswap.h"
+#endif
+
 #include <boost/log/trivial.hpp>
 #include <string.h> // Pour memcpy
 

--- a/src/image/PaletteConfig.h
+++ b/src/image/PaletteConfig.h
@@ -40,7 +40,11 @@
 #include <stdint.h>
 #include "zlib.h"
 #include <string.h>
-#include "byteswap.h"
+#if __has_include("byteswap.h")
+# include "byteswap.h"
+#else
+#include "utils/byteswap.h"
+#endif
 
 static const uint8_t BLACK[3] = {0, 255, 0};
 

--- a/src/image/file/Rok4Image.cpp
+++ b/src/image/file/Rok4Image.cpp
@@ -50,7 +50,12 @@
  */
 
 #include "image/file/Rok4Image.h"
-#include "byteswap.h"
+#if __has_include("byteswap.h")
+# include "byteswap.h"
+#else
+#include "utils/byteswap.h"
+#endif
+
 #include "compressors/LZWEncoder.h"
 #include "compressors/PKBEncoder.h"
 #include "datasource/StoreDataSource.h"

--- a/src/style/Palette.cpp
+++ b/src/style/Palette.cpp
@@ -39,7 +39,12 @@
 #include <stdint.h>
 #include "zlib.h"
 #include <string.h>
-#include "byteswap.h"
+#if __has_include("byteswap.h")
+# include "byteswap.h"
+#else
+#include "utils/byteswap.h"
+#endif
+
 #include <boost/log/trivial.hpp>
 
 Colour::Colour ( uint8_t r, uint8_t g, uint8_t b, int a ) : r ( r ), g ( g ), b ( b ), a ( a ) {

--- a/src/utils/byteswap.h
+++ b/src/utils/byteswap.h
@@ -1,0 +1,26 @@
+#ifndef _BYTESWAP_H
+#define _BYTESWAP_H
+
+#include <stdint.h>
+
+static __inline uint16_t __bswap_16(uint16_t __x)
+{
+	return __x<<8 | __x>>8;
+}
+
+static __inline uint32_t __bswap_32(uint32_t __x)
+{
+	return __x>>24 | __x>>8&0xff00 | __x<<8&0xff0000 | __x<<24;
+}
+
+static __inline uint64_t __bswap_64(uint64_t __x)
+{
+	return __bswap_32(__x)+0ULL<<32 | __bswap_32(__x>>32);
+}
+
+#define bswap_16(x) __bswap_16(x)
+#define bswap_32(x) __bswap_32(x)
+#define bswap_64(x) __bswap_64(x)
+
+#endif
+


### PR DESCRIPTION
byteswap.h n'est pas toujours disponible, il fait partie de la glibc. Rustine pour proposer une compilation multi plateforme.