### PR TITLE
feat(LiburlStruct.h): comparaison des headers en ignore case

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Styles et TMS peuvent être chargés depuis des objets, et sont gérés via un a
 
 * Les chargements des styles et des TMS passent par un système d'annuaire global. Ce dernier s'occupe de lire le fichier (stockage fichier ou objet) dans le cas d'une demande d'un nouveau, ou retourne celui déjà chargé
 
+* Les headers d'authentification sont comparés sans tenir compte de la casse
 
 <!-- 
 ### [Added]

--- a/src/utils/LibcurlStruct.h
+++ b/src/utils/LibcurlStruct.h
@@ -82,19 +82,19 @@ static size_t header_callback(char *buffer, size_t nitems, size_t size, void *us
     size_t realsize = size * nitems;
     struct HeaderStruct* hdr = (HeaderStruct*) userp;
 
-    if (! strncmp ( buffer,"X-Storage-Url: ", 15)) {
+    if (! strcasecmp ( buffer,"X-Storage-Url: ", 15)) {
         hdr->url = (char*) malloc(realsize - 15);
         strncpy(hdr->url, buffer + 15, realsize - 15 - 2);
         hdr->url[realsize - 15 - 2] = '\0';
     }
 
-    else if (! strncmp ( buffer,"X-Auth-Token: ", 14)) {
+    else if (! strcasecmp ( buffer,"X-Auth-Token: ", 14)) {
         hdr->token = (char*) malloc(realsize);
         strncpy(hdr->token, buffer, realsize - 2);
         hdr->token[realsize - 2] = '\0';
     }
 
-    else if (! strncmp ( buffer,"X-Subject-Token: ", 17)) {
+    else if (! strcasecmp ( buffer,"X-Subject-Token: ", 17)) {
         hdr->token = (char*) malloc(realsize - 17 + 14);
         strncpy(hdr->token, "X-Auth-Token: ", 14);
         strncpy(hdr->token + 14, buffer + 17, realsize - 17 - 2);


### PR DESCRIPTION
Certain operateur (OVH swift) renvoie les tokens dans des headers d'authentification en minuscule (x-subject-token au lieu de X-Subject-Token)

Pour être compatible, les headers doivent être comparé en insensible à la casse