### PR TITLE
Fix sur la lecture par morceau avec OpenJpeg

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.1
+
+### [Fixed]
+
+* LibopenjpegImage
+    * Fixe sur la lecture des images à tuile unique suite au zonage
 
 ## 1.1.0
 


### PR DESCRIPTION
Ce correctif s'applique sur des images non tuilées.
Il permet d’éviter la lecture des données hors de la limite d'un tableau de zonage. 