### PR TITLE
Gestion du multi cluster S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 dist
+.vscode

--- a/include/rok4/utils/Cache.h
+++ b/include/rok4/utils/Cache.h
@@ -285,14 +285,16 @@ public:
      * \details Si un contexte existe déjà pour ce nom de contenant, on ne crée pas de nouveau contexte et on retourne celui déjà existant. Le nouveau contexte n'est pas connecté.
      * \param[in] type type de stockage pour lequel on veut créer un contexte
      * \param[in] tray Nom du contenant pour lequel on veut créer un contexte
+     * \param[in] reference_context Contexte de stockage de référence
 
      * \brief Get a context storage
      * \details If a context already exists for this tray's name, we don't create a new one and the existing is returned. New context is not connected.
      * \param[in] type Storage Type for which context is created
      * \param[in] tray Tray's name for which context is created
+     * \param[in] reference_context Reference storage context
      
      */
-    static Context * get_context(ContextType::eContextType type,std::string tray) ;
+    static Context * get_context(ContextType::eContextType type,std::string tray, Context* reference_context = 0) ;
 
 
     /**

--- a/include/rok4/utils/Pyramid.h
+++ b/include/rok4/utils/Pyramid.h
@@ -52,6 +52,7 @@ class Pyramid;
 #include "rok4/enums/Interpolation.h"
 #include "rok4/utils/Configuration.h"
 #include "rok4/utils/Cache.h"
+#include "rok4/storage/Context.h"
 
 #define DEFAULT_NODATAVALUE 255
 
@@ -67,6 +68,12 @@ typedef std::function<bool(std::pair<std::string, Level*>, std::pair<std::string
 class Pyramid : public Configuration {
 
 private:
+
+    /**
+     * \~french \brief Contexte de stockage
+     * \~english \brief Storage context
+     */
+    Context* context;
 
     /**
      * \~french \brief Liste des différents niveaux de la pyramide
@@ -145,6 +152,14 @@ public:
      * \param[in] obj pyramid
      */
     Pyramid (Pyramid* p);
+
+    /**
+     * \~french
+     * \brief Contexte de stockage
+     * \~english
+     * \brief Storage context
+     */
+    Context* getContext ();
 
     /**
      * \~french

--- a/src/datasource/StoreDataSource.cpp
+++ b/src/datasource/StoreDataSource.cpp
@@ -167,7 +167,8 @@ const uint8_t* StoreDataSource::getData ( size_t &tile_size ) {
 
                     if (originalTrayName != tray_name) {
                         // Récupération ou ajout du nouveau contexte de stockage
-                        context = StoragePool::get_context(context->getType(), tray_name);
+                        // On reprécise le contexte d'origine, pour utiliser le même cluster en cas S3
+                        context = StoragePool::get_context(context->getType(), tray_name, context);
                         // Problème lors de l'ajout ou de la récupération de ce contexte de stockage
                         if (context == NULL) {
                             data = NULL;

--- a/src/storage/Context.cpp
+++ b/src/storage/Context.cpp
@@ -52,68 +52,70 @@
 
 namespace ContextType {
 
-/**
- * \~french \brief Noms des types de contextes
- * \~english \brief Available context type names
- */
-const char *eContextTypeName[] = {
-    "unknown",
-    "file",
-    "ceph",
-    "swift",
-    "s3"
-};
+    /**
+     * \~french \brief Noms des types de contextes
+     * \~english \brief Available context type names
+     */
+    const char *eContextTypeName[] = {
+        "unknown",
+        "file",
+        "ceph",
+        "swift",
+        "s3"
+    };
 
-std::string toString ( eContextType ct ) {
-    return std::string ( eContextTypeName[ct] );
-}
-
-eContextType fromString ( std::string strct ) {
-    int i;
-    for ( i = contexttype_size; i ; --i ) {
-        if ( strct.compare ( eContextTypeName[i] ) == 0 )
-            break;
+    std::string toString ( eContextType ct ) {
+        return std::string ( eContextTypeName[ct] );
     }
-    return static_cast<eContextType> ( i );
-}
 
+    eContextType fromString ( std::string strct ) {
+        int i;
+        for ( i = contexttype_size; i ; --i ) {
+            if ( strct.compare ( eContextTypeName[i] ) == 0 )
+                break;
+        }
+        return static_cast<eContextType> ( i );
+    }
 
-void split_path(std::string path, ContextType::eContextType& type, std::string& fo, std::string& tray) {
+    void split_path(std::string path, ContextType::eContextType& type, std::string& fo, std::string& tray) {
 
-    std::stringstream ss(path);
-    std::string token;
-    char delim = ':';
-    std::getline(ss, token, delim);
-    std::string storage_type = token;
+        std::stringstream ss(path);
+        std::string token;
+        char delim = ':';
+        std::getline(ss, token, delim);
+        std::string storage_type = token; // ex. S3
 
-    
-    if (storage_type != path) {
-        // Un type de stockage a été précisé, on l'enlève pour passer à la suite
-        type = ContextType::fromString(storage_type);
-        if (type == ContextType::UNKNOWN) {
+        
+        if (storage_type != path) {
+            // Un type de stockage a été précisé, on l'enlève pour passer à la suite
+            type = ContextType::fromString(storage_type);
+            if (type == ContextType::UNKNOWN) {
+                type = ContextType::FILECONTEXT;
+            }
+            path.erase(0, storage_type.length() + 3); // ex. on enlève S3://
+        } else {
             type = ContextType::FILECONTEXT;
         }
-        path.erase(0, storage_type.length() + 3);
-    } else {
-        type = ContextType::FILECONTEXT;
-    }
 
 
-    if (type == ContextType::FILECONTEXT) {
-        // Dans le cas d'un stockage fichier, le nom du fichier est l'ensemble et on ne définit pas de contenant
-        fo = path;
+        if (type == ContextType::FILECONTEXT) {
+            // Dans le cas d'un stockage fichier, le nom du fichier est l'ensemble et on ne définit pas de contenant
+            fo = path;
+            return;
+        }
+
+        // Dans le cas d'un stockage objet, on sépare le contenant du nom de l'objet
+        // Pour S3, le cluster peut être precisé (facultatif) :
+        //   ex. s3://pyramids@s3.storage.fr:1234/BDORTHO/...
+        ss = std::stringstream(path);
+        delim = '/';
+        std::getline(ss, token, delim);
+        tray = token; // ex. pour S3, layers, pyramids, ... = type de bucket avec/sans cluster
+
+
+        path.erase(0, tray.length() + 1);
+        fo = path; // ex. pour S3, le chemin du fichier dans le bucket
         return;
     }
-
-    // Dans le cas d'un stockage objet, on sépare le contenant du nom de l'objet
-    ss = std::stringstream(path);
-    delim = '/';
-    std::getline(ss, token, delim);
-    tray = token;
-
-    path.erase(0, tray.length() + 1);
-    fo = path;
-    return;
-}
 
 }

--- a/src/storage/S3Context.h
+++ b/src/storage/S3Context.h
@@ -83,11 +83,13 @@ private:
      * \~english \brief S3 API Host (URL without protocol or port)
      */
     std::string host;
+
     /**
      * \~french \brief Clé S3
      * \~english \brief S3 key
      */
     std::string key;
+
     /**
      * \~french \brief Clé de hachage S3
      * \~english \brief S3 hash key
@@ -99,6 +101,12 @@ private:
      * \~english \brief S3 container name
      */
     std::string bucket_name;
+
+     /**
+     * \~french \brief Nom du cluster S3
+     * \~english \brief S3 cluster name
+     */
+    std::string cluster_name;
     
     /**
      * \~french \brief  Ne pas vérifier les certificats SSL avec Curl?
@@ -145,6 +153,7 @@ public:
     ContextType::eContextType getType();
     std::string getTypeStr();
     std::string getTray();
+    std::string getCluster();
 
     int read(uint8_t* data, int offset, int size, std::string name);
     uint8_t* readFull(int& size, std::string name);

--- a/src/storage/S3Context.h
+++ b/src/storage/S3Context.h
@@ -71,7 +71,49 @@
 class S3Context : public Context {
     
 private:
-    
+
+    /**
+     * \~french \brief Liste des URL S3
+     * \~english \brief List of S3 URLs
+     */
+    static std::vector<std::string> env_urls;
+
+    /**
+     * \~french \brief Liste des hôtes S3
+     * \~english \brief List of S3 hosts
+     */
+    static std::vector<std::string> env_hosts;
+
+    /**
+     * \~french \brief Liste des noms de cluster S3
+     * \~english \brief List of S3 cluster names
+     */
+    static std::vector<std::string> env_cluster_names;
+
+    /**
+     * \~french \brief Liste des clés S3
+     * \~english \brief List of S3 keys
+     */
+    static std::vector<std::string> env_keys;
+
+    /**
+     * \~french \brief Liste des clés secrètes S3
+     * \~english \brief List of S3 secret keys
+     */
+    static std::vector<std::string> env_secret_keys;
+
+    /**
+     * \~french \brief  Ne pas vérifier les certificats SSL avec Curl?
+     * \~english \brief Don't verify SSL certificats with Curl ?
+     */
+    static bool ssl_no_verify;
+
+    /**
+     * \~french \brief Charge les informations S3 depuis les variables d'environnement
+     * \~english \brief Load S3 informations from environment variables
+     */
+    static bool load_env();
+
     /**
      * \~french \brief URL de l'API S3, avec protocole et port
      * \~english \brief S3 API URL, with protocol and port
@@ -97,24 +139,16 @@ private:
     std::string secret_key;
 
     /**
-     * \~french \brief Nom du conteneur S3
-     * \~english \brief S3 container name
+     * \~french \brief Nom du conteneur S3, sans nom du cluster
+     * \~english \brief S3 container name, without cluster name
      */
     std::string bucket_name;
 
      /**
-     * \~french \brief Nom du cluster S3
-     * \~english \brief S3 cluster name
+     * \~french \brief Nom du cluster S3 (hôte avec le port)
+     * \~english \brief S3 cluster name (host with port)
      */
     std::string cluster_name;
-    
-    /**
-     * \~french \brief  Ne pas vérifier les certificats SSL avec Curl?
-     * \~english \brief Don't verify SSL certificats with Curl ?
-     */
-    bool ssl_no_verify;
-
-    bool initialized;
 
     /**
      * \~french \brief Calcule la signature à partir du header
@@ -155,6 +189,12 @@ public:
     std::string getTray();
     std::string getCluster();
 
+    /**
+     * \~french \brief Retourne le nom de cluster par défaut (le premier)
+     * \~english \brief Get default S3 cluster name (first one)
+     */
+    static std::string get_default_cluster();
+
     int read(uint8_t* data, int offset, int size, std::string name);
     uint8_t* readFull(int& size, std::string name);
     bool write(uint8_t* data, int offset, int size, std::string name);
@@ -182,6 +222,7 @@ public:
         oss << "\t- Key = " << key << std::endl;
         oss << "\t- Secrete Key = " << secret_key << std::endl;
         oss << "\t- Bucket name = " << bucket_name << std::endl;
+        oss << "\t- Cluster name = " << cluster_name << std::endl;
         if (connected) {
             oss << "\t- CONNECTED !" << std::endl;
         } else {
@@ -200,10 +241,6 @@ public:
 
     void closeConnection() {
         connected = false;
-    }
-
-    bool isInitialized() {
-        return initialized;
     }
 
     ~S3Context() {

--- a/src/storage/S3Context.h
+++ b/src/storage/S3Context.h
@@ -106,6 +106,8 @@ private:
      */
     bool ssl_no_verify;
 
+    bool initialized;
+
     /**
      * \~french \brief Calcule la signature à partir du header
      * \~english \brief Calculate header's signature
@@ -143,7 +145,7 @@ public:
     ContextType::eContextType getType();
     std::string getTypeStr();
     std::string getTray();
-        
+
     int read(uint8_t* data, int offset, int size, std::string name);
     uint8_t* readFull(int& size, std::string name);
     bool write(uint8_t* data, int offset, int size, std::string name);
@@ -179,7 +181,6 @@ public:
         return oss.str() ;
     }
     
-
     /**
      * \~french \brief Récupère l'URL publique #public_url et constitue l'en-tête HTTP #authHdr
      * \~english \brief Get public URL #public_url and constitute the HTTP header #authHdr
@@ -189,7 +190,11 @@ public:
     void closeConnection() {
         connected = false;
     }
-    
+
+    bool isInitialized() {
+        return initialized;
+    }
+
     ~S3Context() {
         closeConnection();
     }

--- a/src/storage/SwiftContext.cpp
+++ b/src/storage/SwiftContext.cpp
@@ -512,6 +512,10 @@ std::string SwiftContext::getTray() {
     return container_name;
 }
 
+bool SwiftContext::writeFromFile(std::string fileName, std::string objectName) {
+    BOOST_LOG_TRIVIAL(warning) << "Not yet implemented !";
+    return false;
+}
 
 bool SwiftContext::openToWrite(std::string name) {
 

--- a/src/storage/SwiftContext.cpp
+++ b/src/storage/SwiftContext.cpp
@@ -512,11 +512,6 @@ std::string SwiftContext::getTray() {
     return container_name;
 }
 
-bool SwiftContext::writeFromFile(std::string fileName, std::string objectName) {
-    BOOST_LOG_TRIVIAL(warning) << "Not yet implemented !";
-    return false;
-}
-
 bool SwiftContext::openToWrite(std::string name) {
 
     std::map<std::string, std::vector<char>*>::iterator it1 = writingBuffers.find ( name );

--- a/src/storage/SwiftContext.h
+++ b/src/storage/SwiftContext.h
@@ -188,18 +188,6 @@ public:
     bool write(uint8_t* data, int offset, int size, std::string name);
     bool writeFull(uint8_t* data, int size, std::string name);
 
-    /**
-     * \~french
-     * \brief Écrit un objet Swift depuis un fichier
-     * \param[in] fileName Nom du fichier à téléverser dans Swift
-     * \param[in] objectName Nom de l'objet Swift
-     * \~english
-     * \brief Écrit un objet Swift depuis un fichier
-     * \param[in] fileName File path to upload into Swift
-     * \param[in] objectName Swift object's name
-     */
-    bool writeFromFile(std::string fileName, std::string objectName);
-
     bool openToWrite(std::string name);
     bool closeToWrite(std::string name);
 

--- a/src/utils/Cache.cpp
+++ b/src/utils/Cache.cpp
@@ -74,7 +74,40 @@ std::string StyleBook::directory = "";
 bool StyleBook::inspire = false;
 std::mutex StyleBook::mtx;
 
-Context * StoragePool::get_context(ContextType::eContextType type,std::string tray) {
+Context * StoragePool::get_context(ContextType::eContextType type, std::string tray, Context* reference_context) {
+
+    if (reference_context != 0 && reference_context->getType() != type) {
+        BOOST_LOG_TRIVIAL(error) << "Asked storage context and reference one have to own the same type";
+        return NULL;
+    }
+
+    if (type == ContextType::S3CONTEXT) {
+        // Dans le cas S3, le nom du bucket peut contenir le nom du cluster ou pas
+        // Pour voir si on a déjà ce contexte de stockage, il faut que "tray" contienne le nom du bucket et du cluster
+        // pour ne pas confondre 2 buckets avec le même nom sur deux clusters différents
+        // On va donc s'assurer d'avoir ce nom de cluster :
+        //    - soit il y est déjà et on le laisse
+        //    - soit il n'y est pas et on met celui du contexte de référence
+        //    - soit il n'y est pas et pas de contexte de référence => on met celui par défaut
+
+        size_t pos = tray.find ( "@" );
+        if ( pos == std::string::npos ) {
+            std::string cluster_name;
+            if (reference_context == 0) {
+                cluster_name = S3Context::get_default_cluster();
+                if (cluster_name == "") {
+                    // Le chargement des informations a échoué (déjà loggé)
+                    return NULL;
+                }
+            } else {
+                // On ajoute le nom du cluster au nom du bucket
+                cluster_name = ((S3Context *)reference_context)->getCluster();
+            }
+
+            tray = tray + "@" + cluster_name;
+        }
+    }
+
     Context* ctx;
     std::pair<ContextType::eContextType,std::string> key = make_pair(type,tray);
 
@@ -97,31 +130,24 @@ Context * StoragePool::get_context(ContextType::eContextType type,std::string tr
                 ctx = new SwiftContext(tray);
                 break;
             case ContextType::S3CONTEXT:
-                // Pour S3, tray = bucket@cluster
                 ctx = new S3Context(tray);
-                if (! ((S3Context *) ctx)->isInitialized()) {
-                    //ERREUR
-                    BOOST_LOG_TRIVIAL(error) << "Le contexte n'a pas pu être initialisé !?";
-                    return NULL;
-                }
                 break;
             case ContextType::FILECONTEXT:
                 ctx = new FileContext(tray);
                 break;
             default:
-                //ERREUR
-                BOOST_LOG_TRIVIAL(error) << "Ce type de contexte n'est pas géré.";
+                BOOST_LOG_TRIVIAL(error) << "Unhandled storage context type";
                 return NULL;
         }
 
         // on connecte pour vérifier que ce contexte est valide
-        if (!(ctx->connection())) {
-            BOOST_LOG_TRIVIAL(error) << "Impossible de connecter au contexte de type " << ContextType::toString(type) << ", contenant " << tray;
+        if (! ctx->connection()) {
+            BOOST_LOG_TRIVIAL(error) << "Cannot connect " << ContextType::toString(type) << " storage context, tray '" << tray << "'";
             delete ctx;
             return NULL;
         }
 
-        BOOST_LOG_TRIVIAL(debug) << "Add storage context " << ContextType::toString(key.first) << " / '" << key.second << "'" ;
+        BOOST_LOG_TRIVIAL(debug) << "Add storage context " << ContextType::toString(type) << ", tray '" << tray << "'";
         pool.insert(make_pair(key,ctx));
 
         return ctx;

--- a/src/utils/Cache.cpp
+++ b/src/utils/Cache.cpp
@@ -77,7 +77,7 @@ Context * StoragePool::get_context(ContextType::eContextType type,std::string tr
 
     std::map<std::pair<ContextType::eContextType,std::string>, Context*>::iterator it = pool.find (key);
     if ( it != pool.end() ) {
-        //le contenant est déjà existant et donc connecté
+        // le contenant est déjà existant et donc connecté
         return it->second;
 
     } else {
@@ -93,7 +93,13 @@ Context * StoragePool::get_context(ContextType::eContextType type,std::string tr
                 ctx = new SwiftContext(tray);
                 break;
             case ContextType::S3CONTEXT:
+                // Pour S3, tray = bucket@cluster
                 ctx = new S3Context(tray);
+                if (! ((S3Context *) ctx)->isInitialized()) {
+                    //ERREUR
+                    BOOST_LOG_TRIVIAL(error) << "Le contexte n'a pas pu être initialisé !?";
+                    return NULL;
+                }
                 break;
             case ContextType::FILECONTEXT:
                 ctx = new FileContext(tray);

--- a/src/utils/Cache.cpp
+++ b/src/utils/Cache.cpp
@@ -77,6 +77,7 @@ Context * StoragePool::get_context(ContextType::eContextType type,std::string tr
 
     std::map<std::pair<ContextType::eContextType,std::string>, Context*>::iterator it = pool.find (key);
     if ( it != pool.end() ) {
+        BOOST_LOG_TRIVIAL(debug) << "Storage context already added " << ContextType::toString(it->first.first) << " / '" << it->first.second << "'" ;
         // le contenant est déjà existant et donc connecté
         return it->second;
 
@@ -122,5 +123,4 @@ Context * StoragePool::get_context(ContextType::eContextType type,std::string tr
 
         return ctx;
     }
-
 }

--- a/src/utils/Level.cpp
+++ b/src/utils/Level.cpp
@@ -185,6 +185,22 @@ Level::Level ( json11::Json doc, Pyramid* pyramid, std::string path) : Configura
             errorMessage = "Level " + id +": cannot add s3 storage context";
             return;
         }
+
+        // INFO
+        // Règles des contextes pour les niveaux (bucket_name = pyramids):
+        //  1. Si le niveau de la pyramide a un contexte sans cluster (par defaut)
+        //    > On utilise le contexte de la pyramide !
+        //  2. Si le niveau de la pyramide a un contexte avec cluster
+        //    > On utilise le contexte du niveau !
+        std::string cluster_level = ((S3Context*) context)->getCluster();
+        if (cluster_level.empty()) {
+            Context* ctx_pyramid = pyramid->getContext();
+            std::string cluster_pyramid = ((S3Context*) ctx_pyramid)->getCluster();
+            if (!cluster_pyramid.empty()) {
+                BOOST_LOG_TRIVIAL(debug) <<  "Using pyramid s3 storage context for the level " << id << " because the cluster is populated" ;
+                context = ctx_pyramid;
+            }
+        }
     }
 #if CEPH_ENABLED
     else if (doc["storage"]["type"].string_value() == "CEPH") {

--- a/src/utils/Pyramid.cpp
+++ b/src/utils/Pyramid.cpp
@@ -213,7 +213,7 @@ Pyramid::Pyramid(std::string path) : Configuration(path) {
     std::string tray_name, fo_name;
     ContextType::split_path(path, storage_type, fo_name, tray_name);
     
-    Context* context = StoragePool::get_context(storage_type, tray_name);
+    context = StoragePool::get_context(storage_type, tray_name);
     if (context == NULL) {
         errorMessage = "Cannot add " + ContextType::toString(storage_type) + " storage context to read pyramid's descriptor";
         return;
@@ -275,6 +275,8 @@ Pyramid::Pyramid (Pyramid* obj) {
         memcpy ( nodataValue, obj->nodataValue, channels * sizeof(int) );
     }
 }
+
+Context* Pyramid::getContext() { return context; }
 
 bool Pyramid::addLevels (Pyramid* obj, std::string bottomLevel, std::string topLevel) {
 


### PR DESCRIPTION
cf. https://github.com/rok4/core-cpp/issues/11

## Procédure de test du multi cluster S3

:information_source: Utilisation de l'utilitaire [mc](https://min.io/docs/minio/linux/reference/minio-mc/) pour modifier les données MinIO.

on met en place plusieurs clusters : my-s3-1, my-s3-2
  * avec les ports : 9000, 8000
  * avec les urls UI : localhost:9001, localhost:8001

On utilise la commande docker : `docker run --name my-s3-1 -p 9000:9000 -p 9001:9001 rok4/dataset:minio`


Le cluster _my-s3-1_ contient la liste des layers :
```bash
$ mc cat my-s3-1/layers/list.txt
s3://layers/BDORTHO.json
s3://layers/ALTI.json   --> map : TIFF_ZIP_FLOAT32
s3://layers/LIMADM.json --> vector : TIFF_PBF_MVT
s3://layers/PENTE.json
```

Les layers sont sur le cluster _my-s3-1_ :
```bash
$ mc ls my-s3-1/layers/
[2022-12-13 13:59:39 CET]   723B STANDARD ALTI.json
[2022-12-06 16:27:51 CET]   641B STANDARD BDORTHO.json
[2022-12-06 16:12:01 CET]   324B STANDARD LIMADM.json
[2022-12-12 21:33:37 CET]   635B STANDARD PENTE.json
```

Visualisation d'une config de _layers_ :
```bash
$ mc cat my-s3-1/layers/BDORTHO.json
{
   "pyramids" : [
      {
         "bottom_level" : "15",
         "top_level" : "0",
         "path" : "s3://pyramids/BDORTHO.json"
      }
   ],
   "title" : "BDORTHO",
   "tms" : {
      "authorized" : true
   },
   "styles" : [
      "normal"
   ],
   "wmts" : {
      "authorized" : true
   },
   "abstract" : "Diffusion de la donnée BDORTHO",
   "resampling" : "bicubic",
   "wms" : {
      "authorized" : true,
      "crs" : [
         "EPSG:3857",
         "CRS:84",
         "IGNF:WGS84G",
         "EPSG:3857",
         "EPSG:4258",
         "EPSG:4326"
      ]
   },
   "keywords" : [
      "PM",
      "TIFF_JPG_UINT8"
   ]
}

```

Le path du descripteur de pyramide pointe sur le cluster par défaut (_my-s3-1_) : 
`s3://pyramids/BDORTHO.json`

On modifie le path vers le descripteur pour qu'il pointe vers un autre cluster (_my-s3-2_) :
`s3://pyramids/BDORTHO.json --> s3://pyramids@localhost:8000/BDORTHO.json`

On utilise la commande `mc cp` pour copier le nouveau fichier de config du layers.

Le résultat attendu est de récupérer la donnée sur le bon cluster _my-s3-2_ lors de l'appel de la requête suivante :
`curl -v "http://localhost:8091/rok4/wmts?SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=BDORTHO&STYLE=normal&FORMAT=image/jpeg&TILEMATRIXSET=PM&TILEMATRIX=15&TILEROW=15042&TILECOL=10829" --output test.jpg`

Pour vérifier que l'appel soit sur la bonne url de cluster, on vérifie les logs :
```text
info	LAYERS LOADING
debug	Add storage context s3 / 'layers'
debug	S3 read full : layers@localhost / list.txt
debug	Add layer BDORTHO from file or object
debug	Storage context already added s3 / 'layers'
debug	S3 read full : layers@localhost / BDORTHO.json
debug	Add storage context s3 / 'pyramids@localhost:8000'
debug	S3 read full : pyramids@localhost:8000 / BDORTHO.json
debug	Add storage context s3 / 'pyramids'

debug	Using pyramid s3 storage context for the level 0 because the cluster is populated
debug	Storage context already added s3 / 'pyramids'
debug	Using pyramid s3 storage context for the level 1 because the cluster is populated
debug	Storage context already added s3 / 'pyramids'
debug	Using pyramid s3 storage context for the level 2 because the cluster is populated
debug	Storage context already added s3 / 'pyramids'
debug	Using pyramid s3 storage context for the level 3 because the cluster is populated
debug	Storage context already added s3 / 'pyramids'
debug	Using pyramid s3 storage context for the level 4 because the cluster is populated
debug	Storage context already added s3 / 'pyramids'
(...)
debug	pyramide composée de 1 pyramide(s)
```
et 
```text
debug	Request: GET /wmts
debug	Query parameters: SERVICE=WMTS&REQUEST=GetTile&VERSION=1.0.0&LAYER=BDORTHO&STYLE=normal&FORMAT=image/jpeg&TILEMATRIXSET=PM&TILEMATRIX=15&TILEROW=15042&TILECOL=10829
debug	First part of path :wmts
debug	format requete : image/jpeg format pyramide : image/jpeg
debug	BDORTHO/DATA_15_676_940
debug	input slab pyramids/BDORTHO/DATA_15_676_940
debug	pas de cache
debug	S3 read : 4096 bytes (from the 0 one) in the object pyramids@localhost:8000 / BDORTHO/DATA_15_676_940
debug	S3 READ START (4096) 140737268151872
debug	S3 READ END (4096) 140737268151872
debug	S3 read : 6187 bytes (from the 289152 one) in the object pyramids@localhost:8000 / BDORTHO/DATA_15_676_940
debug	S3 READ START (6187) 140737268151872
debug	S3 READ END (6187) 140737268151872
debug	image.jpg
debug	End of Response
```
:warning:  Surveiller que l'appel des tuiles avec liens symboliques soient avec le contexte en cours ! Idem pour le cache !