### PR TITLE
Correction de la copie de LegendURL

### DIFF
--- a/include/rok4/utils/LegendURL.h
+++ b/include/rok4/utils/LegendURL.h
@@ -140,6 +140,8 @@ public:
      * \param[in] origLUrl LegendURL to copy
      */
     LegendURL ( const LegendURL &origLUrl ) {
+        href = origLUrl.href;
+        format = origLUrl.format;
         height = origLUrl.height;
         width = origLUrl.width;
         maxScaleDenominator = origLUrl.maxScaleDenominator;


### PR DESCRIPTION
### [Fixed]

* La fonction de copie d'une instance LegendURL recopie bien le format et le href