### PR TITLE
Correction de la lectur de JPEG 2000 tuilé

### DIFF
--- a/src/image/file/openjpeg/LibopenjpegImage.h
+++ b/src/image/file/openjpeg/LibopenjpegImage.h
@@ -66,8 +66,6 @@
  * \~french
  * \brief Manipulation d'une image JPEG2000, avec la librarie openjpeg
  * \details Une image JPEG2000 est une vraie image dans ce sens où elle est rattachée à un fichier, pour la lecture de données au format JPEG2000. La librairie utilisée est openjpeg (open source et intégrée statiquement dans le projet ROK4).
- * 
- * \todo Lire au fur et à mesure l'image JPEG2000 et ne pas la charger intégralement en mémoire lors de la création de l'objet LibopenjpegImage.
  */
 class LibopenjpegImage : public FileImage {
     
@@ -76,10 +74,10 @@ friend class LibopenjpegImageFactory;
 private:
      
     /**
-     * \~french \brief Est ce que la donnée est tuilée ?
-     * \~english \brief Is the data tiled ?
+     * \~french \brief Largeur pixel de la tuile, 0 si la donnée n'est pas tuilée
+     * \~english \brief Tile pixel width, 0 if data is not tiled
      */
-    bool tiled;
+    int tile_width;
     /**
      * \~french \brief Nombre de ligne dans un strip
      * \~english \brief Number of line in one strip
@@ -97,12 +95,16 @@ private:
     int current_strip;
 
     /**
-     * \~french \brief Stockage de l'image entière, décompressée
-     * \~english \brief Full uncompressed image storage
+     * \~french \brief Paramètres OpenJPEG
+     * \~english \brief OpenJPEG parameters
      */
-    opj_image_t* jp2_image;
-    opj_stream_t* jp2_stream;
-    opj_codec_t* jp2_codec; 
+    opj_dparameters_t jp2_parameters;
+
+    /**
+     * \~french \brief Format du codec OpenJPEG
+     * \~english \brief OpenJPEG codec format
+     */
+    OPJ_CODEC_FORMAT jp2_codec;
 
     /** \~french
      * \brief Retourne une ligne, flottante ou entière
@@ -133,7 +135,7 @@ protected:
      * \param[in] stream pointeur vers l'objet stream OpenJPEG
      * \param[in] codec pointeur vers l'objet codec OpenJPEG
      * \param[in] rowsperstrip taille de la bufferisation des données, en nombre de lignes
-     * \param[in] tiled est ce que la donnée est tuilée
+     * \param[in] tw Largeur pixel de la tuile, 0 si la donnée n'est pas tuilée
      ** \~english
      * \brief Create a LibopenjpegImage object, from all attributes
      * \param[in] width image width, in pixel
@@ -147,16 +149,14 @@ protected:
      * \param[in] bitspersample number of bits per sample
      * \param[in] photometric data photometric
      * \param[in] compression data compression
-     * \param[in] image OpenJPEG image's pointer
-     * \param[in] stream OpenJPEG stream's pointer
-     * \param[in] codec OpenJPEG codec's pointer
+     * \param[in] parameters OpenJPEG parameters
      * \param[in] rowsperstrip data buffering size, in line number
-     * \param[in] tiled Is the data tiled ?
+     * \param[in] tw Tile pixel width, 0 if data is not tiled
      */
     LibopenjpegImage (
         int width, int height, double resx, double resy, int channels, BoundingBox< double > bbox, std::string name,
         SampleFormat::eSampleFormat sampleformat, int bitspersample, Photometric::ePhotometric photometric, Compression::eCompression compression,
-        opj_image_t* image, opj_stream_t* stream, opj_codec_t* codec, int rowsperstrip, bool tiled
+        opj_dparameters_t parameters, OPJ_CODEC_FORMAT codec_format, int rowsperstrip, int tw
     );
 
 public:
@@ -272,9 +272,6 @@ public:
      * \details We remove read buffers
      */
     ~LibopenjpegImage() {
-        opj_destroy_codec ( jp2_codec );
-        opj_stream_destroy ( jp2_stream );
-        opj_image_destroy( jp2_image );
         delete [] strip_buffer;
     }
 


### PR DESCRIPTION
### [Fixed]

* `LibopenjpegImage` : la lecture des images JPEG 2000 tuilées recharge l'image à la lecture de chaque tuile