### PR TITLE
Échappement des back quotes dans les valeurs des attributs

### DIFF
--- a/include/rok4/utils/Attribute.h
+++ b/include/rok4/utils/Attribute.h
@@ -96,6 +96,10 @@ class Attribute
                 std::string tmp;
                 for (json11::Json v : doc["values"].array_items()) {
                     tmp = v.string_value();
+                    // on double les backslash, en évitant de traiter les backslash déjà doublés
+                    boost::replace_all(tmp, "\\\\", "\\");
+                    boost::replace_all(tmp, "\\", "\\\\");
+                    // On échappe les doubles quotes
                     boost::replace_all(tmp, "\"", "\\\"");
                     values.push_back(tmp);
                 }


### PR DESCRIPTION
### [Fixed]

* Attribute : dans les valeurs des attributs, on échappe les éventuelles back quotes