### PR TITLE
Correction de l'encodage de TiffDeflateEncoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ### [Fixed]
 
 * `TiffDeflateEncoder` : l'encodage du résultat final n'est pas en deflate (seule la donnée dans le tiff l'est, et non le résultat complet)
+* `S3Context` : on retourne bien false lorsqu'une erreur est rencontrée lors du flush (close_to_write)
+
 
 ## 2.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.2
+
+### [Fixed]
+
+* `TiffDeflateEncoder` : l'encodage du résultat final n'est pas en deflate (seule la donnée dans le tiff l'est, et non le résultat complet)
+
 ## 2.0.1
 
 ### [Added]

--- a/include/rok4/datastream/TiffDeflateEncoder.h
+++ b/include/rok4/datastream/TiffDeflateEncoder.h
@@ -160,7 +160,7 @@ public:
     }
 
     std::string get_encoding() {
-        return "deflate";
+        return "";
     }
 };
 

--- a/src/storage/S3Context.cpp
+++ b/src/storage/S3Context.cpp
@@ -656,7 +656,7 @@ bool S3Context::close_to_write(std::string name) {
 
     BOOST_LOG_TRIVIAL(error) <<  "Unable to flush " << it1->second->size() << " bytes in the S3 object " << bucket_name << "@" << ((cluster_name != "") ? cluster_name : host) << " / " << name << " after " << write_attempts << " tries" ;
 
-    return true;
+    return false;
 }
 
 bool S3Context::exists(std::string name) {


### PR DESCRIPTION
### [Fixed]

* `TiffDeflateEncoder` : l'encodage du résultat final n'est pas en deflate (seule la donnée dans le tiff l'est, et non le résultat complet)
* `S3Context` : on retourne bien false lorsqu'une erreur est rencontrée lors du flush (close_to_write)