### PR TITLE
Gestion des données MNT en Terrain RGB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/) et ce pr
 - Ajout du traitement en cas de style terrainrgb. Il doit être l'unique style déclaré pour fonctionner.
 
 ### Changed
-
-- `Style` : Vérification de l'existance d'un bloc palette dans le json de style avant la création d'un objet palette. Ce changement nécessite la vérification de l'existance d'une palette qui n'était pas vérifié avant.
-
 ### Deprecated
 ### Removed
 ### Fixed
+
+- `Style` : Vérification de l'existance d'un bloc palette dans le json de style avant la création d'un objet palette. Ce changement nécessite la vérification de l'existance d'une palette qui n'était pas vérifié avant.
+
 ### Security
 
 ## [2.0.6] - 2025-09-11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,13 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/) et ce pr
 
 - `Terrainrgb` : Ajout d'un style terrainrgb pour transformer les MNT en format Terrain RGB.
 - `TerrainrgbImage` : Ajout du processus de traitement du style Terrainrgb. 
+- `Style` : Ajout d'une fonction permettant de savoir si une palette existe ou non.
+- Ajout du traitement en cas de style terrainrgb. Il doit être l'unique style déclaré pour fonctionner.
 
 ### Changed
+
+- `Style` : Vérification de l'existance d'un bloc palette dans le json de style avant la création d'un objet palette. Ce changement nécessite la vérification de l'existance d'une palette qui n'était pas vérifié avant.
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/) et ce pr
 ## [Unreleased]
 
 ### Added
+
+- `Terrainrgb` : Ajout d'un style terrainrgb pour transformer les MNT en format Terrain RGB.
+- `TerrainrgbImage` : Ajout du processus de traitement du style Terrainrgb. 
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/include/rok4/image/TerrainrgbImage.h
+++ b/include/rok4/image/TerrainrgbImage.h
@@ -35,6 +35,14 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 
+/**
+ * \file TerrainrgbImage.h
+ ** \~french
+ * \brief D�finition de la classe TerrainrgbImage
+ ** \~english
+ * \brief Define class TerrainrgbImage
+ */
+
 #pragma once
 
 #include "rok4/image/Image.h"

--- a/include/rok4/image/TerrainrgbImage.h
+++ b/include/rok4/image/TerrainrgbImage.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright © (2011) Institut national de l'information
+ *                    géographique et forestière
+ *
+ * Géoportail SAV <contact.geoservices@ign.fr>
+ *
+ * This software is a computer program whose purpose is to publish geographic
+ * data using OGC WMS and WMTS protocol.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ *
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+#pragma once
+
+#include "rok4/image/Image.h"
+#include "rok4/style/Terrainrgb.h"
+
+class TerrainrgbImage : public Image
+{
+private:
+    Image *source_image;
+    Terrainrgb *terrainrgb;
+
+    template <typename T>
+    int _getline(T *buffer, int line);
+
+public:
+    virtual int get_line(float *buffer, int line);
+    virtual int get_line(uint16_t *buffer, int line);
+    virtual int get_line(uint8_t *buffer, int line);
+    TerrainrgbImage(Image *image, Terrainrgb *terrainrgb);
+    virtual ~TerrainrgbImage();
+};

--- a/include/rok4/style/Style.h
+++ b/include/rok4/style/Style.h
@@ -225,7 +225,7 @@ public:
      * \~english \brief Style is allowed ?
      */
     bool handle (int spp) {
-        if (estompage_defined() || pente_defined() || aspect_defined()) {
+        if (estompage_defined() || pente_defined() || aspect_defined() || terrainrgb_defined()) {
             return (spp == 1);
         } else {
             return true;
@@ -243,7 +243,11 @@ public:
             } else {
                 return 4;
             }
-        } else {
+        } 
+        else if (terrainrgb_defined()){
+                return 3;
+            }
+        else {
             if (estompage_defined() || pente_defined() || aspect_defined()) {
                 return 1;
             } else {
@@ -251,6 +255,7 @@ public:
                 return orig_channels;
             }
         }
+        
     }
 
     /**
@@ -258,7 +263,7 @@ public:
      * \~english \brief Which sample format after style
      */
     SampleFormat::eSampleFormat get_sample_format (SampleFormat::eSampleFormat sf) {
-        if (palette && ! palette->is_empty()) {
+        if ((palette && ! palette->is_empty()) || terrainrgb_defined()) {
             return SampleFormat::UINT8;
         } else {
             return sf;

--- a/include/rok4/style/Style.h
+++ b/include/rok4/style/Style.h
@@ -360,6 +360,17 @@ public:
 
     /**
      * \~french
+     * \brief Détermine si le style décrit une table de correspondance
+     * \return true si oui
+     * \~english
+     * \brief Determine if the style describe a lookup table
+     * \return true if it does
+     */
+    inline bool palette_defined() {
+        return (palette != 0);
+    }
+    /**
+     * \~french
      * \brief Retourne la table de correspondance
      * \return table de correspondance
      * \~english

--- a/include/rok4/style/Style.h
+++ b/include/rok4/style/Style.h
@@ -164,7 +164,7 @@ private :
      */
     Estompage* estompage;
     /**
-     * \~french \brief Définit si un terrainrgb doit être appliqué
+     * \~french \brief Définit si un calcul de terrainrgb doit être appliqué
      * \~english \brief Define wether the server must compute a RGB terrain
      */
     Terrainrgb* terrainrgb;

--- a/include/rok4/style/Style.h
+++ b/include/rok4/style/Style.h
@@ -298,7 +298,7 @@ public:
             return false;
         }
 
-        if (estompage_defined() || pente_defined() || aspect_defined()) {
+        if (estompage_defined() || pente_defined() || aspect_defined() || terrainrgb_defined()) {
             return false;
         } else {
             return true;
@@ -426,6 +426,27 @@ public:
      */
     inline Aspect* get_aspect() {
         return aspect;
+    }
+
+    /**
+    * \~french
+    * \brief Return vrai si le style est un terrainrgb
+    * \return bool
+    * \~english
+    * \brief Return true if the style is an rgb terrain
+    * \return bool
+    */
+    inline bool terrainrgb_defined() {
+        return (terrainrgb != 0);
+    }
+    /**
+     * \~french
+     * \brief Retourne le terrainrgb
+     * \~english
+     * \brief Return rgb terrain
+     */
+    inline Terrainrgb* get_terrainrgb() {
+        return terrainrgb;
     }
 	
 

--- a/include/rok4/style/Style.h
+++ b/include/rok4/style/Style.h
@@ -55,6 +55,7 @@ class Style;
 #include "rok4/style/Pente.h"
 #include "rok4/style/Estompage.h"
 #include "rok4/style/Aspect.h"
+#include "rok4/style/Terrainrgb.h"
 #include "rok4/enums/Interpolation.h"
 #include "rok4/utils/Configuration.h"
 #include "rok4/enums/Format.h"
@@ -162,6 +163,11 @@ private :
      * \~english \brief Define wether the server must compute a relief shadow
      */
     Estompage* estompage;
+    /**
+     * \~french \brief Définit si un terrainrgb doit être appliqué
+     * \~english \brief Define wether the server must compute a RGB terrain
+     */
+    Terrainrgb* terrainrgb;
 
     /**
      * \~french \brief Valeur de nodata attendue dans les données en entrée

--- a/include/rok4/style/Terrainrgb.h
+++ b/include/rok4/style/Terrainrgb.h
@@ -46,7 +46,7 @@
 
 class Terrainrgb : public Configuration
 {
-private:
+public:
     /** \~french
      * \brief min_elevation : élévation minimale à partir de laquelle est calculée la couleur
      ** \~english
@@ -61,7 +61,6 @@ private:
      */
     float step;
 
-public:
     /**
      * \~french
      * \brief Constructeurs avec des arguments

--- a/include/rok4/style/Terrainrgb.h
+++ b/include/rok4/style/Terrainrgb.h
@@ -55,9 +55,9 @@ public:
     int min_elevation;
 
     /** \~french
-     * \brief step : écart d'altitude entre deux couleurs différentes
+     * \brief step : résolution verticale
      ** \~english
-     * \brief step : altitude difference between two different colors
+     * \brief step : vertical resolution
      */
     float step;
 
@@ -69,9 +69,9 @@ public:
     float input_nodata_value;
 
     /** \~french
-    * \brief noData : valeur de nodata pour l'image source
+    * \brief noData : valeur de nodata pour le terrainrgb
     ** \~english
-    * \brief noData : value of nodata for the source image
+    * \brief noData : value of nodata for the RGB terrain
     */
     float terrainrgb_nodata_value;
 

--- a/include/rok4/style/Terrainrgb.h
+++ b/include/rok4/style/Terrainrgb.h
@@ -68,6 +68,13 @@ public:
     */
     float input_nodata_value;
 
+    /** \~french
+    * \brief noData : valeur de nodata pour l'image source
+    ** \~english
+    * \brief noData : value of nodata for the source image
+    */
+    float terrainrgb_nodata_value;
+
     /**
      * \~french
      * \brief Constructeurs avec des arguments

--- a/include/rok4/style/Terrainrgb.h
+++ b/include/rok4/style/Terrainrgb.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright © (2011) Institut national de l'information
+ *                    géographique et forestière
+ *
+ * Géoportail SAV <contact.geoservices@ign.fr>
+ *
+ * This software is a computer program whose purpose is to publish geographic
+ * data using OGC WMS and WMTS protocol.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ *
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+#pragma once
+
+#include "rok4/utils/Configuration.h"
+
+#include <stdint.h>
+#include <vector>
+#include <map>
+#include <stddef.h>
+
+class Terrainrgb : public Configuration
+{
+private:
+    /** \~french
+     * \brief min_elevation : élévation minimale à partir de laquelle est calculée la couleur
+     ** \~english
+     * \brief min_elevation : minimum elevation from which the color is calculated
+     */
+    int min_elevation;
+
+    /** \~french
+     * \brief step : écart d'altitude entre deux couleurs différentes
+     ** \~english
+     * \brief step : altitude difference between two different colors
+     */
+    float step;
+
+public:
+    /**
+     * \~french
+     * \brief Constructeurs avec des arguments
+     * \~english
+     * \brief Constructor with arguments
+     */
+    Terrainrgb(json11::Json doc);
+
+    /**
+     * \~french
+     * \brief Destructeur
+     * \~english
+     * \brief Destructor
+     */
+    virtual ~Terrainrgb();
+};

--- a/include/rok4/style/Terrainrgb.h
+++ b/include/rok4/style/Terrainrgb.h
@@ -61,6 +61,13 @@ public:
      */
     float step;
 
+    /** \~french
+    * \brief noData : valeur de nodata pour l'image source
+    ** \~english
+    * \brief noData : value of nodata for the source image
+    */
+    float input_nodata_value;
+
     /**
      * \~french
      * \brief Constructeurs avec des arguments

--- a/include/rok4/style/Terrainrgb.h
+++ b/include/rok4/style/Terrainrgb.h
@@ -35,6 +35,15 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 
+ /**
+ * \file Terrainrgb.h
+ ** \~french
+ * \brief D�finition de la classe Terrainrgb
+ ** \~english
+ * \brief Define class Terrainrgb
+ */
+
+
 #pragma once
 
 #include "rok4/utils/Configuration.h"

--- a/src/image/TerrainrgbImage.cpp
+++ b/src/image/TerrainrgbImage.cpp
@@ -38,7 +38,6 @@
 #include "image/TerrainrgbImage.h"
 
 #include <boost/log/trivial.hpp>
-#include "TerrainrgbImage.h"
 
 int TerrainrgbImage::get_line(float *buffer, int line)
 {

--- a/src/image/TerrainrgbImage.cpp
+++ b/src/image/TerrainrgbImage.cpp
@@ -1,0 +1,123 @@
+/*
+ * Copyright © (2011) Institut national de l'information
+ *                    géographique et forestière
+ *
+ * Géoportail SAV <contact.geoservices@ign.fr>
+ *
+ * This software is a computer program whose purpose is to publish geographic
+ * data using OGC WMS and WMTS protocol.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ *
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+#include "image/TerrainrgbImage.h"
+
+#include <boost/log/trivial.hpp>
+#include "TerrainrgbImage.h"
+
+int TerrainrgbImage::get_line(float *buffer, int line)
+{
+    if (source_image->get_channels() == 1)
+    {
+        return _getline(buffer, line);
+    }
+    else
+    {
+        return source_image->get_line(buffer, line);
+    }
+}
+
+int TerrainrgbImage::get_line(uint16_t *buffer, int line)
+{
+    if (source_image->get_channels() == 1)
+    {
+        return _getline(buffer, line);
+    }
+    else
+    {
+        return source_image->get_line(buffer, line);
+    }
+}
+
+int TerrainrgbImage::get_line(uint8_t *buffer, int line)
+{
+    if (source_image->get_channels() == 1)
+    {
+        return _getline(buffer, line);
+    }
+    else
+    {
+        return source_image->get_line(buffer, line);
+    }
+}
+
+TerrainrgbImage::TerrainrgbImage(Image *image, Terrainrgb *Terrainrgb) : Image(image->get_width(), image->get_height(), 1, image->get_bbox()), source_image(image)
+{
+    // Il n'y aura application de la palette et modification des canaux que si
+    // - la palette n'est pas nulle et pas vide
+    // - l'image source est sur un canal
+    if (source_image->get_channels() == 1)
+    {
+        channels = 3;
+    }
+    else
+    {
+        channels = image->get_channels();
+    }
+}
+
+TerrainrgbImage::~TerrainrgbImage()
+{
+    delete source_image;
+}
+
+template <typename T>
+int TerrainrgbImage::_getline(T *buffer, int line)
+{
+    float *source = new float[source_image->get_width() * source_image->get_channels()];
+    source_image->get_line(source, line);
+    switch (channels)
+    {
+
+    case 3:
+        for (int i = 0; i < source_image->get_width(); i++)
+        {
+            int base = *buffer + terrainrgb->min_elevation / terrainrgb->step;
+            int red = abs(base / (256 * 256)) % 256;
+            int green = abs((base - red * 256 * 256) / 256) % 256;
+            int blue = abs(base - red * 256 * 256 - green * 256);
+            *(buffer + i * 3) = red;
+            *(buffer + i * 3 + 1) = green;
+            *(buffer + i * 3 + 2) = blue;
+        }
+        break;
+    }
+
+    delete[] source;
+    return width * sizeof(T) * channels;
+}

--- a/src/image/TerrainrgbImage.cpp
+++ b/src/image/TerrainrgbImage.cpp
@@ -77,9 +77,6 @@ int TerrainrgbImage::get_line(uint8_t *buffer, int line)
 
 TerrainrgbImage::TerrainrgbImage(Image *image, Terrainrgb *Terrainrgb) : Image(image->get_width(), image->get_height(), 1, image->get_bbox()), source_image(image)
 {
-    // Il n'y aura application de la palette et modification des canaux que si
-    // - la palette n'est pas nulle et pas vide
-    // - l'image source est sur un canal
     if (source_image->get_channels() == 1)
     {
         channels = 3;

--- a/src/image/TerrainrgbImage.cpp
+++ b/src/image/TerrainrgbImage.cpp
@@ -39,56 +39,39 @@
 
 #include <boost/log/trivial.hpp>
 
-int TerrainrgbImage::get_line(float *buffer, int line)
-{
-    if (source_image->get_channels() == 1)
-    {
+int TerrainrgbImage::get_line(float *buffer, int line) {
+    if (source_image->get_channels() == 1) {
         return _getline(buffer, line);
-    }
-    else
-    {
+    } else {
         return source_image->get_line(buffer, line);
     }
 }
 
-int TerrainrgbImage::get_line(uint16_t *buffer, int line)
-{
-    if (source_image->get_channels() == 1)
-    {
+int TerrainrgbImage::get_line(uint16_t *buffer, int line) {
+    if (source_image->get_channels() == 1) {
         return _getline(buffer, line);
-    }
-    else
-    {
+    } else {
         return source_image->get_line(buffer, line);
     }
 }
 
-int TerrainrgbImage::get_line(uint8_t *buffer, int line)
-{
-    if (source_image->get_channels() == 1)
-    {
+int TerrainrgbImage::get_line(uint8_t *buffer, int line) {
+    if (source_image->get_channels() == 1) {
         return _getline(buffer, line);
-    }
-    else
-    {
+    } else {
         return source_image->get_line(buffer, line);
     }
 }
 
-TerrainrgbImage::TerrainrgbImage(Image *image, Terrainrgb *terrainrgb) : Image(image->get_width(), image->get_height(), 1, image->get_bbox()), source_image(image), terrainrgb(terrainrgb)
-{
-    if (source_image->get_channels() == 1)
-    {
+TerrainrgbImage::TerrainrgbImage(Image *image, Terrainrgb *terrainrgb) : Image(image->get_width(), image->get_height(), 1, image->get_bbox()), source_image(image), terrainrgb(terrainrgb) {
+    if (source_image->get_channels() == 1) {
         channels = 3;
-    }
-    else
-    {
+    } else {
         channels = image->get_channels();
     }
 } 
 
-TerrainrgbImage::~TerrainrgbImage()
-{
+TerrainrgbImage::~TerrainrgbImage() {
     delete source_image;
 }
 
@@ -100,18 +83,18 @@ int TerrainrgbImage::_getline ( T* buffer, int line ) {
     case 3:
         for (int i = 0; i < source_image->get_width() ; i++ ) {
             
+            // découpage de l'altitude en RGB suivant la formule suivante : height = min_elevation + ((Red * 256 * 256 + Green * 256 + Blue) * step)
             int base = (std::max((T) *(source+i), (T) terrainrgb->min_elevation) -  terrainrgb->min_elevation) / terrainrgb->step;
             int red = (base / (256 * 256) % 256);
             int green = ((base - red * 256 * 256) / 256 % 256);
             int blue = (base - red * 256 * 256 - green * 256);
+
             * ( buffer+i*3 ) = (T) red;
             * ( buffer+i*3+1 ) = (T) green;
             * ( buffer+i*3+2 ) = (T) blue;
         }
         break;
     }
-
-    
 
     delete[] source;
     return width * sizeof ( T ) * channels;

--- a/src/image/TerrainrgbImage.cpp
+++ b/src/image/TerrainrgbImage.cpp
@@ -35,6 +35,13 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 
+ /**
+ * \file TerrainrgbImage.cpp
+ * \~french
+ * \brief Implémentation de la classe TerrainrgbImage permettant l'application du terrainrgb à une image.
+ * \~english
+ * \brief Implement the TerrainrgbImage Class handling computing of Terrainrgb style to an image.
+ */
 #include "image/TerrainrgbImage.h"
 
 #include <boost/log/trivial.hpp>

--- a/src/image/TerrainrgbImage.cpp
+++ b/src/image/TerrainrgbImage.cpp
@@ -75,7 +75,7 @@ int TerrainrgbImage::get_line(uint8_t *buffer, int line)
     }
 }
 
-TerrainrgbImage::TerrainrgbImage(Image *image, Terrainrgb *Terrainrgb) : Image(image->get_width(), image->get_height(), 1, image->get_bbox()), source_image(image)
+TerrainrgbImage::TerrainrgbImage(Image *image, Terrainrgb *terrainrgb) : Image(image->get_width(), image->get_height(), 1, image->get_bbox()), source_image(image), terrainrgb(terrainrgb)
 {
     if (source_image->get_channels() == 1)
     {
@@ -85,35 +85,34 @@ TerrainrgbImage::TerrainrgbImage(Image *image, Terrainrgb *Terrainrgb) : Image(i
     {
         channels = image->get_channels();
     }
-}
+} 
 
 TerrainrgbImage::~TerrainrgbImage()
 {
     delete source_image;
 }
 
-template <typename T>
-int TerrainrgbImage::_getline(T *buffer, int line)
-{
-    float *source = new float[source_image->get_width() * source_image->get_channels()];
-    source_image->get_line(source, line);
-    switch (channels)
-    {
-
+template<typename T>
+int TerrainrgbImage::_getline ( T* buffer, int line ) {
+    float* source = new float[source_image->get_width() * source_image->get_channels()];
+    source_image->get_line ( source, line );
+    switch ( channels ) {
     case 3:
-        for (int i = 0; i < source_image->get_width(); i++)
-        {
-            int base = *buffer + terrainrgb->min_elevation / terrainrgb->step;
-            int red = abs(base / (256 * 256)) % 256;
-            int green = abs((base - red * 256 * 256) / 256) % 256;
-            int blue = abs(base - red * 256 * 256 - green * 256);
-            *(buffer + i * 3) = red;
-            *(buffer + i * 3 + 1) = green;
-            *(buffer + i * 3 + 2) = blue;
+        for (int i = 0; i < source_image->get_width() ; i++ ) {
+            
+            int base = (std::max((T) *(source+i), (T) terrainrgb->min_elevation) -  terrainrgb->min_elevation) / terrainrgb->step;
+            int red = (base / (256 * 256) % 256);
+            int green = ((base - red * 256 * 256) / 256 % 256);
+            int blue = (base - red * 256 * 256 - green * 256);
+            * ( buffer+i*3 ) = (T) red;
+            * ( buffer+i*3+1 ) = (T) green;
+            * ( buffer+i*3+2 ) = (T) blue;
         }
         break;
     }
 
+    
+
     delete[] source;
-    return width * sizeof(T) * channels;
+    return width * sizeof ( T ) * channels;
 }

--- a/src/style/Style.cpp
+++ b/src/style/Style.cpp
@@ -267,8 +267,10 @@ Style::Style ( std::string path ) : Configuration(path) {
         output_nodata_value[0] = (int) pente->slope_nodata_value;
     }
     else if (terrainrgb_defined()) {
-        output_nodata_value = new int[1];
-        output_nodata_value[0] = (int) terrainrgb->terrainrgb_nodata_value;
+        output_nodata_value = new int[3];
+            output_nodata_value[0] = 0;
+            output_nodata_value[1] = 0;
+            output_nodata_value[2] = 0;
     }
 }
 

--- a/src/style/Style.cpp
+++ b/src/style/Style.cpp
@@ -107,12 +107,10 @@ bool Style::parse(json11::Json& doc) {
         legends.push_back(leg);
     }
 
-    if (doc["palette"].is_object()){
-        palette = new Palette(doc["palette"].object_items());
-        if (! palette->is_ok()) {
-            error_message = "Palette issue for style " + id + ": " + palette->get_error_message();
-        return false;
-        }
+    palette = new Palette(doc["palette"].object_items());
+    if (! palette->is_ok()) {
+        error_message = "Palette issue for style " + id + ": " + palette->get_error_message();
+    return false;
     }
 
     if (doc["estompage"].is_object()) {
@@ -234,7 +232,6 @@ Style::Style ( std::string path ) : Configuration(path) {
     else if (terrainrgb_defined()) {
         input_nodata_value = new int[1];
         input_nodata_value[0] = (int) terrainrgb->input_nodata_value;
-        return;
     }  
     else if (palette && ! palette->is_empty()) {
         input_nodata_value = new int[1];

--- a/src/style/Style.cpp
+++ b/src/style/Style.cpp
@@ -110,7 +110,6 @@ bool Style::parse(json11::Json& doc) {
     if (doc["palette"].is_object()){
         palette = new Palette(doc["palette"].object_items());
         if (! palette->is_ok()) {
-            BOOST_LOG_TRIVIAL(warning) << "Palette";
             error_message = "Palette issue for style " + id + ": " + palette->get_error_message();
         return false;
         }
@@ -150,12 +149,11 @@ bool Style::parse(json11::Json& doc) {
 
     if (doc["terrainrgb"].is_object()) {
         terrainrgb = new Terrainrgb(doc["terrainrgb"].object_items());
-        if (! terrainrgb->is_ok() || palette->is_ok()) {
+        if (! terrainrgb->is_ok()) {
             error_message = "Terrainrgb issue for style " + id + ": " + terrainrgb->get_error_message();
             return false;
         }
     }
-
     return true;
 }
 
@@ -165,6 +163,7 @@ Style::Style ( std::string path ) : Configuration(path) {
     estompage = 0;
     palette = 0;
     aspect = 0;
+    terrainrgb = 0;
 
     input_nodata_value = NULL;
     output_nodata_value = NULL;
@@ -231,7 +230,12 @@ Style::Style ( std::string path ) : Configuration(path) {
     else if (pente_defined()) {
         input_nodata_value = new int[1];
         input_nodata_value[0] = (int) pente->input_nodata_value;
-    } 
+    }
+    else if (terrainrgb_defined()) {
+        input_nodata_value = new int[1];
+        input_nodata_value[0] = (int) terrainrgb->input_nodata_value;
+        return;
+    }  
     else if (palette && ! palette->is_empty()) {
         input_nodata_value = new int[1];
         input_nodata_value[0] = (int) palette->get_colours_map()->begin()->first;
@@ -265,6 +269,10 @@ Style::Style ( std::string path ) : Configuration(path) {
         output_nodata_value = new int[1];
         output_nodata_value[0] = (int) pente->slope_nodata_value;
     }
+    else if (terrainrgb_defined()) {
+        output_nodata_value = new int[1];
+        output_nodata_value[0] = (int) terrainrgb->terrainrgb_nodata_value;
+    }
 }
 
 Style::~Style() {
@@ -279,6 +287,9 @@ Style::~Style() {
     }
     if (aspect != 0) {
         delete aspect;
+    }
+    if (terrainrgb != 0) {
+        delete terrainrgb;
     }
     if (input_nodata_value != NULL) {
         delete[] input_nodata_value;

--- a/src/style/Style.cpp
+++ b/src/style/Style.cpp
@@ -62,6 +62,7 @@ bool Style::parse(json11::Json& doc) {
     aspect = 0;
     estompage = 0;
     palette = 0;
+    terrainrgb = 0;
 
     input_nodata_value = NULL;
     output_nodata_value = NULL;
@@ -106,10 +107,13 @@ bool Style::parse(json11::Json& doc) {
         legends.push_back(leg);
     }
 
-    palette = new Palette(doc["palette"].object_items());
-    if (! palette->is_ok()) {
-        error_message = "Palette issue for style " + id + ": " + palette->get_error_message();
+    if (doc["palette"].is_object()){
+        palette = new Palette(doc["palette"].object_items());
+        if (! palette->is_ok()) {
+            BOOST_LOG_TRIVIAL(warning) << "Palette";
+            error_message = "Palette issue for style " + id + ": " + palette->get_error_message();
         return false;
+        }
     }
 
     if (doc["estompage"].is_object()) {
@@ -140,6 +144,14 @@ bool Style::parse(json11::Json& doc) {
         aspect = new Aspect(doc["exposition"].object_items());
         if (! aspect->is_ok()) {
             error_message = "Aspect issue for style " + id + ": " + aspect->get_error_message();
+            return false;
+        }
+    }
+
+    if (doc["terrainrgb"].is_object()) {
+        terrainrgb = new Terrainrgb(doc["terrainrgb"].object_items());
+        if (! terrainrgb->is_ok() || palette->is_ok()) {
+            error_message = "Terrainrgb issue for style " + id + ": " + terrainrgb->get_error_message();
             return false;
         }
     }

--- a/src/style/Style.cpp
+++ b/src/style/Style.cpp
@@ -107,10 +107,12 @@ bool Style::parse(json11::Json& doc) {
         legends.push_back(leg);
     }
 
-    palette = new Palette(doc["palette"].object_items());
-    if (! palette->is_ok()) {
-        error_message = "Palette issue for style " + id + ": " + palette->get_error_message();
-    return false;
+    if (doc["palette"].is_object()) {
+        palette = new Palette(doc["palette"].object_items());
+        if (! palette->is_ok()) {
+            error_message = "Palette issue for style " + id + ": " + palette->get_error_message();
+        return false;
+        }
     }
 
     if (doc["estompage"].is_object()) {
@@ -146,6 +148,10 @@ bool Style::parse(json11::Json& doc) {
     }
 
     if (doc["terrainrgb"].is_object()) {
+        if (estompage != 0 || pente != 0 || aspect !=0 || palette !=0) {
+            error_message = "Style " + id + " define exposition, estompage, pente or palette rules";
+            return false;
+        }
         terrainrgb = new Terrainrgb(doc["terrainrgb"].object_items());
         if (! terrainrgb->is_ok()) {
             error_message = "Terrainrgb issue for style " + id + ": " + terrainrgb->get_error_message();
@@ -255,8 +261,8 @@ Style::Style ( std::string path ) : Configuration(path) {
         }
     }
     else if (estompage_defined()) {
-            output_nodata_value = new int[1];
-            output_nodata_value[0] = (int) estompage->estompage_nodata_value;
+        output_nodata_value = new int[1];
+        output_nodata_value[0] = (int) estompage->estompage_nodata_value;
     }
     else if (aspect_defined()) {
         output_nodata_value = new int[1];
@@ -268,9 +274,9 @@ Style::Style ( std::string path ) : Configuration(path) {
     }
     else if (terrainrgb_defined()) {
         output_nodata_value = new int[3];
-            output_nodata_value[0] = 0;
-            output_nodata_value[1] = 0;
-            output_nodata_value[2] = 0;
+        output_nodata_value[0] = 0;
+        output_nodata_value[1] = 0;
+        output_nodata_value[2] = 0;
     }
 }
 

--- a/src/style/Terrainrgb.cpp
+++ b/src/style/Terrainrgb.cpp
@@ -35,6 +35,14 @@
  * knowledge of the CeCILL-C license and that you accept its terms.
  */
 
+ /**
+ * \file Terrainrgb.cpp
+ * \~french
+ * \brief Implémentation de la classe Terrainrgb modélisant un terrainrgb.
+ * \~english
+ * \brief Implement the Terrainrgb Class handling terrainrgb definition.
+ */
+
 #include "style/Terrainrgb.h"
 #include <stdint.h>
 #include "zlib.h"

--- a/src/style/Terrainrgb.cpp
+++ b/src/style/Terrainrgb.cpp
@@ -40,7 +40,7 @@
  * \~french
  * \brief Implémentation de la classe Terrainrgb modélisant un terrainrgb.
  * \~english
- * \brief Implement the Terrainrgb Class handling terrainrgb definition.
+ * \brief Implement the Terrainrgb Class handling RGB terrain definition.
  */
 
 #include "style/Terrainrgb.h"

--- a/src/style/Terrainrgb.cpp
+++ b/src/style/Terrainrgb.cpp
@@ -42,7 +42,7 @@
 #include "byteswap.h"
 #include <boost/log/trivial.hpp>
 
-Terrainrgb::Terrainrgb(json11::Json doc) : Configuration()
+Terrainrgb::Terrainrgb(json11::Json doc) : Configuration(), input_nodata_value (-99999)
 {
 
     if (doc["min_elevation"].is_number())

--- a/src/style/Terrainrgb.cpp
+++ b/src/style/Terrainrgb.cpp
@@ -45,25 +45,18 @@
 Terrainrgb::Terrainrgb(json11::Json doc) : Configuration()
 {
 
-    if (doc["min_elevation"].is_number())
-    {
+    if (doc["min_elevation"].is_number()) {
         min_elevation = doc["min_elevation"].number_value();
-    }
-    else
-    {
+    } else {
         min_elevation = -10000;
     }
-    if (doc["step"].is_number())
-    {
+    if (doc["step"].is_number()) {
         step = doc["step"].number_value();
-    }
-    else
-    {
+    } else {
         step = 0.1;
     }
     input_nodata_value=min_elevation;
 }
 
-Terrainrgb::~Terrainrgb()
-{
+Terrainrgb::~Terrainrgb() {
 }

--- a/src/style/Terrainrgb.cpp
+++ b/src/style/Terrainrgb.cpp
@@ -42,7 +42,7 @@
 #include "byteswap.h"
 #include <boost/log/trivial.hpp>
 
-Terrainrgb::Terrainrgb(json11::Json doc) : Configuration(), input_nodata_value (-99999)
+Terrainrgb::Terrainrgb(json11::Json doc) : Configuration(), input_nodata_value (-99999), terrainrgb_nodata_value(-10000)
 {
 
     if (doc["min_elevation"].is_number())

--- a/src/style/Terrainrgb.cpp
+++ b/src/style/Terrainrgb.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright © (2011) Institut national de l'information
+ *                    géographique et forestière
+ *
+ * Géoportail SAV <contact.geoservices@ign.fr>
+ *
+ * This software is a computer program whose purpose is to publish geographic
+ * data using OGC WMS and WMTS protocol.
+ *
+ * This software is governed by the CeCILL-C license under French law and
+ * abiding by the rules of distribution of free software.  You can  use,
+ * modify and/ or redistribute the software under the terms of the CeCILL-C
+ * license as circulated by CEA, CNRS and INRIA at the following URL
+ * "http://www.cecill.info".
+ *
+ * As a counterpart to the access to the source code and  rights to copy,
+ * modify and redistribute granted by the license, users are provided only
+ * with a limited warranty  and the software's author,  the holder of the
+ * economic rights,  and the successive licensors  have only  limited
+ * liability.
+ *
+ * In this respect, the user's attention is drawn to the risks associated
+ * with loading,  using,  modifying and/or developing or reproducing the
+ * software by the user in light of its specific status of free software,
+ * that may mean  that it is complicated to manipulate,  and  that  also
+ * therefore means  that it is reserved for developers  and  experienced
+ * professionals having in-depth computer knowledge. Users are therefore
+ * encouraged to load and test the software's suitability as regards their
+ * requirements in conditions enabling the security of their systems and/or
+ * data to be ensured and,  more generally, to use and operate it in the
+ * same conditions as regards security.
+ *
+ * The fact that you are presently reading this means that you have had
+ *
+ * knowledge of the CeCILL-C license and that you accept its terms.
+ */
+
+#include "style/Terrainrgb.h"
+#include <stdint.h>
+#include "zlib.h"
+#include <string.h>
+#include "byteswap.h"
+#include <boost/log/trivial.hpp>
+
+Terrainrgb::Terrainrgb(json11::Json doc) : Configuration()
+{
+
+    if (doc["min_elevation"].is_number())
+    {
+        min_elevation = doc["min_elevation"].number_value();
+    }
+    else
+    {
+        BOOST_LOG_TRIVIAL(warning) << "Wrong format for terrainrgb, terrainrgb ignored";
+        return;
+    }
+    if (doc["step"].is_number())
+    {
+        min_elevation = doc["step"].number_value();
+    }
+    else
+    {
+        BOOST_LOG_TRIVIAL(warning) << "Wrong format for terrainrgb, terrainrgb ignored";
+        return;
+    }
+}
+
+Terrainrgb::~Terrainrgb()
+{
+}

--- a/src/style/Terrainrgb.cpp
+++ b/src/style/Terrainrgb.cpp
@@ -42,7 +42,7 @@
 #include "byteswap.h"
 #include <boost/log/trivial.hpp>
 
-Terrainrgb::Terrainrgb(json11::Json doc) : Configuration(), input_nodata_value (-99999), terrainrgb_nodata_value(-10000)
+Terrainrgb::Terrainrgb(json11::Json doc) : Configuration()
 {
 
     if (doc["min_elevation"].is_number())
@@ -51,18 +51,17 @@ Terrainrgb::Terrainrgb(json11::Json doc) : Configuration(), input_nodata_value (
     }
     else
     {
-        BOOST_LOG_TRIVIAL(warning) << "Wrong format for terrainrgb, terrainrgb ignored";
-        return;
+        min_elevation = -10000;
     }
     if (doc["step"].is_number())
     {
-        min_elevation = doc["step"].number_value();
+        step = doc["step"].number_value();
     }
     else
     {
-        BOOST_LOG_TRIVIAL(warning) << "Wrong format for terrainrgb, terrainrgb ignored";
-        return;
+        step = 0.1;
     }
+    input_nodata_value=min_elevation;
 }
 
 Terrainrgb::~Terrainrgb()


### PR DESCRIPTION
Ajout du style Terrainrgb afin de transformer un format MNT en image RGB suivant la formule : 
```
hauteur = min_elevation + ((R * 256 * 256 + G * 256 + B) *pas) 
``` 
