### PR TITLE
fix(ogc) : IGNGPF-5480 Mise en place de valeur limite pour la boundingbox en wms-r

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Le format est basé sur [Keep a Changelog](https://keepachangelog.com/) et ce pr
 
 - Compilation des artefacts sous ubuntu 24.04 (compatible debian 13 / trixie)
 
+### Fixed
+
+-   `Boundingbox` : Mise en place de valeur maximale et minimale pour les bbox en wms-r.
+
 ## [3.0.0] - 2026-03-12
 
 ### Added

--- a/include/rok4/utils/BoundingBox.h
+++ b/include/rok4/utils/BoundingBox.h
@@ -409,10 +409,10 @@ public:
 
         if (geographical) {
             ptree& node = parent.add("EX_GeographicBoundingBox", "");
-            node.add("westBoundLongitude", xmin);
-            node.add("eastBoundLongitude", xmax);
-            node.add("southBoundLatitude", ymin);
-            node.add("northBoundLatitude", ymax);
+            node.add("westBoundLongitude", std::max(xmin,-180.0));
+            node.add("eastBoundLongitude", std::min(xmax,180.0));
+            node.add("southBoundLatitude", std::max(ymin,-90.0));
+            node.add("northBoundLatitude", std::min(ymax,90.0));
         } else {
             ptree& node = parent.add("BoundingBox", "");
             node.add("<xmlattr>.CRS", crs);


### PR DESCRIPTION
Ajout de valeur limite pour la création de la bbox lors de l'utilisation du wms-r.